### PR TITLE
Fix gradle issues (2021)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,15 +25,14 @@ version = "1.0-SNAPSHOT"
 
 repositories {
     jcenter()
-    maven("https://kotlin.bintray.com/kotlinx/")
-    maven("https://dl.bintray.com/devexperts/Maven")
+    mavenCentral()
 }
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(kotlin("reflect"))
     testImplementation(kotlin("test-junit"))
-    testImplementation("org.jetbrains.kotlinx:lincheck:2.4")
+    testImplementation("org.jetbrains.kotlinx:lincheck-jvm:2.14.1")
 }
 
 sourceSets["main"].java.setSrcDirs(listOf("src"))

--- a/test/LinearizabilityTest.kt
+++ b/test/LinearizabilityTest.kt
@@ -1,5 +1,5 @@
 import org.jetbrains.kotlinx.lincheck.*
-import org.jetbrains.kotlinx.lincheck.annotations.*
+import org.jetbrains.kotlinx.lincheck.annotations.Operation
 import org.jetbrains.kotlinx.lincheck.strategy.stress.*
 import org.jetbrains.kotlinx.lincheck.verifier.*
 import kotlin.test.*


### PR DESCRIPTION
This PR fixes build failures with:

```> Could not resolve all files for configuration ':testCompileClasspath'.```

and

```test/LinearizabilityTest.kt: (13, 6): Unresolved reference: Operation```